### PR TITLE
Preserve original context

### DIFF
--- a/lib/promisify.js
+++ b/lib/promisify.js
@@ -51,10 +51,8 @@ module.exports = function (original, custom) {
 
     return function () {
         // Store original context
-        var _this = this;
-
-        // Parse out the original arguments
-        var args = Array.prototype.slice.call(arguments);
+        var that = this,
+            args = Array.prototype.slice.call(arguments);
 
         // Return the promisified function
         return new Promise(function (resolve, reject) {
@@ -66,7 +64,7 @@ module.exports = function (original, custom) {
             args.push(callback.bind(null, ctx));
 
             // Call the function
-            original.apply(_this, args);
+            original.apply(that, args);
         });
     };
 };

--- a/lib/promisify.js
+++ b/lib/promisify.js
@@ -50,6 +50,8 @@ function callback(ctx, err, result) {
 module.exports = function (original, custom) {
 
     return function () {
+        // Store original context
+        var _this = this;
 
         // Parse out the original arguments
         var args = Array.prototype.slice.call(arguments);
@@ -64,7 +66,7 @@ module.exports = function (original, custom) {
             args.push(callback.bind(null, ctx));
 
             // Call the function
-            original.apply(original, args);
+            original.apply(_this, args);
         });
     };
 };

--- a/package.json
+++ b/package.json
@@ -4,12 +4,17 @@
   "description": "Converts callback-based functions to ES6 Promises",
   "main": "lib/promisify.js",
   "author": "Mike Hall <mikehall314@gmail.com>",
-  "keywords": ["promises", "es6", "promisify"],
+  "keywords": [
+    "promises",
+    "es6",
+    "promisify"
+  ],
   "license": "MIT",
   "dependencies": {
     "es6-promise": "^1.0.0"
   },
   "scripts": {
+    "pretest": "jslint ./lib/* ./tests/*",
     "test": "nodeunit tests"
   },
   "bugs": "http://github.com/twistdigital/es6-promisify/issues",
@@ -22,6 +27,7 @@
     "url": "https://github.com/twistdigital/es6-promisify.git"
   },
   "devDependencies": {
+    "jslint": "^0.9.0",
     "nodeunit": "^0.9.0"
   }
 }

--- a/tests/promisify-tests.js
+++ b/tests/promisify-tests.js
@@ -22,7 +22,7 @@ function standard(fail, callback) {
 o = {
     "thing": true,
     "method": function (callback) {
-        if (this.thing) {
+        if (this && this.thing) {
             return callback(null, "thing");
         }
         callback("error");
@@ -164,6 +164,26 @@ module.exports = {
 
             // Should reject the promise and land in here.
             test.equal(because, "error", "Unexpected error value");
+
+        }).then(test.done);
+    },
+
+    "promisify method with default callback (same context)": function (test) {
+
+        test.expect(1);
+
+        // Promisify a method, preserving it's parent context
+        o.methodPromisified = promisify(o.method);
+
+        o.methodPromisified().then(function kept(thing) {
+
+            // String should equal success
+            test.equal(thing, "thing", "Unexpected return value");
+
+        }, function broken(because) {
+
+            // We shouldn't get in here, if we do we rejected unexpectedly
+            test.ok(false, "Unexpected rejection: " + because);
 
         }).then(test.done);
     },


### PR DESCRIPTION
Calling original function in the context of a function is useless, we'd much better preserve original context.

This will also fix this: https://github.com/twistdigital/es6-promisify/issues/5