### PR TITLE
Keep original context if 2nd parameter is true

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,38 @@ client("ping", []).then(function (pong) {
 });
 ```
 
+## Promisify instance methods
+```js
+"use strict";
+
+// Declare variables
+var promisify, fs, fileReader;
+
+// Load modules
+promisify = require("es6-promisify");
+fs        = require("fs");
+
+// Declare a class and an instance method
+function FileReader(filename) {
+    this.filename = filename;
+}
+FileReader.prototype.read = function (done) {
+    fs.readFile(this.filename, done);
+};
+
+// Create a promise-based version of an instance method
+FileReader.prototype.read = promisify(FileReader.prototype.read, true);
+
+// Create new instance
+fileReader = new FileReader("example.txt");
+
+fileReader.read().then(function (data) {
+    console.log("Got data", data);
+}).catch(function (err) {
+    // err = "Could not read file"
+});
+```
+
 ### Tests
 Test with nodeunit
 ```bash

--- a/lib/promisify.js
+++ b/lib/promisify.js
@@ -48,15 +48,38 @@ function callback(ctx, err, result) {
 }
 
 module.exports = function (original, custom) {
+    // Keep original context
+    if (custom === true) {
+        return function () {
+            var originalCtx = this;
+
+            // Parse out the original arguments
+            var args = Array.prototype.slice.call(arguments);
+
+            // Return the promisified function
+            return new Promise(function (resolve, reject) {
+                var then = function (err, result) {
+                    if (err) {
+                        return reject(err);
+                    }
+                    resolve(result);
+                };
+
+                // Append the callback bound to the context
+                args.push(then);
+
+                // Call the function
+                original.apply(originalCtx, args);
+            });
+        };
+    }
 
     return function () {
-
         // Parse out the original arguments
         var args = Array.prototype.slice.call(arguments);
 
         // Return the promisified function
         return new Promise(function (resolve, reject) {
-
             // Create a Context object
             var ctx = new Context(resolve, reject, custom);
 


### PR DESCRIPTION
### Overview
When I try to promisify some instance methods, it doesn't work well because 'this' context is replaced. I added functionality to keep original context if 2nd parameter is true.