### PR TITLE
Correctly handle callbacks with more than two arguments

### DIFF
--- a/lib/promisify.js
+++ b/lib/promisify.js
@@ -28,9 +28,16 @@ function Context(resolve, reject, custom) {
 }
 
 // Default callback function - rejects on truthy error, otherwise resolves
-function callback(ctx, err, result) {
+function callback() {
+    var args = Array.prototype.slice.call(arguments),
+        ctx = args.shift(),
+        err = args.shift(),
+        cust;
+
+    args = args.length > 1 ? args : args[0];
+
     if (typeof ctx.custom === 'function') {
-        var cust = function () {
+        cust = function () {
             // Bind the callback to itself, so the resolve and reject
             // properties that we bound are available to the callback.
             // Then we push it onto the end of the arguments array.
@@ -38,12 +45,12 @@ function callback(ctx, err, result) {
         };
         cust.resolve = ctx.resolve;
         cust.reject = ctx.reject;
-        cust.call(null, err, result);
+        cust.call(null, err, args);
     } else {
         if (err) {
             return ctx.reject(err);
         }
-        ctx.resolve(result);
+        ctx.resolve(args);
     }
 }
 

--- a/tests/promisify-tests.js
+++ b/tests/promisify-tests.js
@@ -257,5 +257,17 @@ module.exports = {
         ]).then(function (results) {
             test.deepEqual(results, [1, 2, 3], "Unexpected result array");
         }).then(test.done);
+    },
+
+    "promisified function callback with multiple arguments": function (test) {
+        var promisified = promisify(function (cb) {
+            setTimeout(function () {
+                cb(null, 1, 2, 3);
+            });
+        });
+
+        promisified().then(function (result) {
+            test.deepEqual(result, [1, 2, 3], "Unexpected result array");
+        }).then(test.done);
     }
 };


### PR DESCRIPTION
If the promisified function calls the callback with more than two arguments (e.g., `cb(null, 1, 2, 3)`) then the result of the Promise should be an array (e.g., `[1, 2, 3]`).